### PR TITLE
feat: wrap content in <article> tags for text-to-speech

### DIFF
--- a/csbu-html.xsl
+++ b/csbu-html.xsl
@@ -19,6 +19,33 @@
 <xsl:param name="suppress.navigation" select="0"></xsl:param>
 <xsl:param name="html.stylesheet">csbu.css</xsl:param>
 
+
+<xsl:variable name="articleOpen">
+<xsl:text disable-output-escaping="yes">
+<![CDATA[
+<article>
+]]>
+</xsl:text>
+</xsl:variable>
+
+<xsl:template name="user.header.content">
+    <xsl:value-of select="$articleOpen" disable-output-escaping="yes"/>
+</xsl:template>
+
+
+<xsl:variable name="articleClose">
+<xsl:text disable-output-escaping="yes">
+<![CDATA[
+</article>
+]]>
+</xsl:text>
+</xsl:variable>
+
+<xsl:template name="user.footer.content">
+    <xsl:value-of select="$articleClose" disable-output-escaping="yes"/>
+</xsl:template>
+
+
 <xsl:template name="user.footer.navigation">
 <script type="text/javascript">
 


### PR DESCRIPTION
This is horribly hacky - is there a better way to achieve this? 

Rationale is that without `CDATA` tags the XML doesn't validate, and without `disable-output-escaping` the `<article>` tag is escaped and not parsed as markup.